### PR TITLE
Add lock reason to describe-locks response

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -322,6 +322,11 @@ func (s *SlackListener) describeLocks() slack.MsgOption {
 			buf.WriteString(": ")
 			if lock.Locked {
 				buf.WriteString("Locked")
+				if len(lock.LockHistory) > 0 {
+					buf.WriteString(" (")
+					buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].Reason)
+					buf.WriteString(")")
+				}
 			} else {
 				buf.WriteString("Unlocked")
 			}

--- a/slack_test.go
+++ b/slack_test.go
@@ -270,7 +270,7 @@ func TestSlackLockUnlock(t *testing.T) {
 		Text:    "describe locks",
 	}))
 	require.Equal(t, `myproject1
-  production: Locked
+  production: Locked (deployment of revision a)
 `, nextMessage().Text())
 
 	// User 1 is a developer so cannot unlock the project forcefully


### PR DESCRIPTION
This enhances #1128 to include the lock reason to the `describe locks` response.