### PR TITLE
Include who-locked-it in `describe locks` response

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -323,7 +323,9 @@ func (s *SlackListener) describeLocks() slack.MsgOption {
 			if lock.Locked {
 				buf.WriteString("Locked")
 				if len(lock.LockHistory) > 0 {
-					buf.WriteString(" (")
+					buf.WriteString(" (by ")
+					buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].User)
+					buf.WriteString(", for ")
 					buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].Reason)
 					buf.WriteString(")")
 				}

--- a/slack.go
+++ b/slack.go
@@ -285,7 +285,7 @@ func (s *SlackListener) lock(cmd *slackcmd.Lock, triggeredBy User, replyIn strin
 		return s.errorMessage(err.Error())
 	}
 
-	if err := s.getOrCreateCoordinator().Lock(context.Background(), cmd.Project, cmd.Env, triggeredBy.SlackUserID, cmd.Reason); err != nil {
+	if err := s.getOrCreateCoordinator().Lock(context.Background(), cmd.Project, cmd.Env, triggeredBy.SlackDisplayName, cmd.Reason); err != nil {
 		return s.errorMessage(err.Error())
 	}
 
@@ -298,7 +298,7 @@ func (s *SlackListener) unlock(cmd *slackcmd.Unlock, triggeredBy User, replyIn s
 		return s.errorMessage(err.Error())
 	}
 
-	if err := s.getOrCreateCoordinator().Unlock(context.Background(), cmd.Project, cmd.Env, triggeredBy.SlackUserID, triggeredBy.IsAdmin()); err != nil {
+	if err := s.getOrCreateCoordinator().Unlock(context.Background(), cmd.Project, cmd.Env, triggeredBy.SlackDisplayName, triggeredBy.IsAdmin()); err != nil {
 		return s.errorMessage(err.Error())
 	}
 

--- a/slack_test.go
+++ b/slack_test.go
@@ -279,7 +279,7 @@ func TestSlackLockUnlock(t *testing.T) {
 		Channel: "C1234",
 		Text:    "unlock myproject1 production",
 	}))
-	require.Equal(t, "user U1234 is not allowed to unlock this project", nextMessage().Text())
+	require.Equal(t, "user user1 is not allowed to unlock this project", nextMessage().Text())
 
 	// User 4 is an admin and can unlock the project forcefully
 	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{

--- a/slack_test.go
+++ b/slack_test.go
@@ -270,7 +270,7 @@ func TestSlackLockUnlock(t *testing.T) {
 		Text:    "describe locks",
 	}))
 	require.Equal(t, `myproject1
-  production: Locked (deployment of revision a)
+  production: Locked (by user2, for deployment of revision a)
 `, nextMessage().Text())
 
 	// User 1 is a developer so cannot unlock the project forcefully


### PR DESCRIPTION
I made two changes on top of #1134 to let `describe locks` responses include who locked deployments:

- f8a5362a067b82c7feb2b6ebf3a249f46e938e1e: Uses Slack username instead of user ID as the identifier of who-locked-this. Usernames are more human-readable than IDs.
- 8360b34cc65a1eba60095097731cc53a33faf29a: Surfaces the Slack usernames persisted in who-locked-this configmap to `descibe locks` responses.
