### PR TITLE
More describe-locks test

### DIFF
--- a/deploy/lock_test.go
+++ b/deploy/lock_test.go
@@ -94,7 +94,7 @@ func TestDescribeLocks(t *testing.T) {
 
 	require.NoError(t, c.Lock(ctx, "myproject1", "prod", "user1", "for deployment of revision a"))
 
-	locks, err := c.DescribeLocks(ctx)
+	locks, err := c.describeLocks(ctx)
 	require.NoError(t, err)
 	require.Len(t, locks, 1)
 
@@ -114,7 +114,7 @@ func TestDescribeLocks(t *testing.T) {
 
 	require.NoError(t, c.Unlock(ctx, "myproject1", "prod", "user1", false))
 
-	locks, err = c.DescribeLocks(ctx)
+	locks, err = c.describeLocks(ctx)
 	require.NoError(t, err)
 	require.Len(t, locks, 1)
 	require.Equal(t, map[string]Phase{

--- a/slack.go
+++ b/slack.go
@@ -307,16 +307,19 @@ func (s *SlackListener) unlock(cmd *slackcmd.Unlock, triggeredBy User, replyIn s
 
 // describeLocks describes the locks of all projects and environments, and replies to the given channel.
 func (s *SlackListener) describeLocks() slack.MsgOption {
-	locks, err := s.getOrCreateCoordinator().DescribeLocks(context.Background())
+	projects, err := s.getOrCreateCoordinator().DescribeLocks(context.Background())
 	if err != nil {
 		return s.errorMessage(err.Error())
 	}
 
 	var buf strings.Builder
-	for project, envs := range locks {
+	for _, pj := range projects {
+		project := pj.Name
+		envs := pj.Phases
 		buf.WriteString(project)
 		buf.WriteString("\n")
-		for env, lock := range envs {
+		for _, lock := range envs {
+			env := lock.Name
 			buf.WriteString("  ")
 			buf.WriteString(env)
 			buf.WriteString(": ")

--- a/slack_test.go
+++ b/slack_test.go
@@ -363,6 +363,27 @@ myproject2
 myproject2
   staging: Locked (by user2, for deployment of revision c)
 `, nextMessage().Text())
+
+	// Unlock project 2 staging
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1235",
+		Channel: "C1234",
+		Text:    "unlock myproject2 staging",
+	}))
+	require.Equal(t, "Unlocked myproject2 staging", nextMessage().Text())
+
+	// Describe locks
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1235",
+		Channel: "C1234",
+		Text:    "describe locks",
+	}))
+	require.Equal(t, `myproject1
+  production: Unlocked
+  staging: Locked (by user2, for deployment of revision b)
+myproject2
+  staging: Unlocked
+`, nextMessage().Text())
 }
 
 // Message is a message posted to the fake Slack API's chat.postMessage endpoint


### PR DESCRIPTION
Made three changes to test `describe-locks` more throughout:

- 9b9048b82e6163c96bfcdc8e3bfd2018a2911ab3: `DescribeLocks` now returns a sorted slice of `ProjectDesc`, which is also a collection of sorted `PhaseDesc`s.
  Previously, project and phase ordering within a `describe-locks` response was dependent on how the underlying Go `map` stored and returned projects and phases, which resulted in flaky test when we had to test `describe-locks` with multiple projects and phases.
  This fixes that by sorting projects and phases before generating a response.
- 40adddbda6de7f5d7b727af224b95c75dfbf83e1: Enhances the test to cover multiple projects- previously we tested with only one project `myproject1`. Now we test with two.
- 26c085015a4ce2b80fee3b0f934edc3accea9554: Enhances the test to cover multiple phases- previously we tested only with `production`. We now have `staging` too.