### PR TITLE
Hide unlocked phases on describe-locks

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -319,21 +319,21 @@ func (s *SlackListener) describeLocks() slack.MsgOption {
 		buf.WriteString(project)
 		buf.WriteString("\n")
 		for _, lock := range envs {
+			if !lock.Locked {
+				continue
+			}
+
 			env := lock.Name
 			buf.WriteString("  ")
 			buf.WriteString(env)
 			buf.WriteString(": ")
-			if lock.Locked {
-				buf.WriteString("Locked")
-				if len(lock.LockHistory) > 0 {
-					buf.WriteString(" (by ")
-					buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].User)
-					buf.WriteString(", for ")
-					buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].Reason)
-					buf.WriteString(")")
-				}
-			} else {
-				buf.WriteString("Unlocked")
+			buf.WriteString("Locked")
+			if len(lock.LockHistory) > 0 {
+				buf.WriteString(" (by ")
+				buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].User)
+				buf.WriteString(", for ")
+				buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].Reason)
+				buf.WriteString(")")
 			}
 			buf.WriteString("\n")
 		}

--- a/slack_test.go
+++ b/slack_test.go
@@ -358,7 +358,6 @@ myproject2
 		Text:    "describe locks",
 	}))
 	require.Equal(t, `myproject1
-  production: Unlocked
   staging: Locked (by user2, for deployment of revision b)
 myproject2
   staging: Locked (by user2, for deployment of revision c)
@@ -379,10 +378,8 @@ myproject2
 		Text:    "describe locks",
 	}))
 	require.Equal(t, `myproject1
-  production: Unlocked
   staging: Locked (by user2, for deployment of revision b)
 myproject2
-  staging: Unlocked
 `, nextMessage().Text())
 }
 


### PR DESCRIPTION
This modifies `describe-locks` to only show locked phases, so that you don't need to search for a few locked phases over dozens of  locked and unlocked phases.