### PR TITLE
fix failed to push kufu-ai/gocat:latest: push access denied, reposito…

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,6 +18,7 @@ env:
   IMAGE_NAME: gocat
   DOCKERHUB_USER: yasukexxx
   PLATFORMS: linux/arm64,linux/amd64
+  DOCKERHUB_REPO_OWNER: davinci-std
 
 jobs:
   # Run tests.
@@ -75,7 +76,7 @@ jobs:
 
       - name: Build and Push image
         run: |
-          IMAGE_ID=${{ github.repository_owner }}/$IMAGE_NAME
+          IMAGE_ID=$DOCKERHUB_REPO_OWNER/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')


### PR DESCRIPTION
### **User description**
…ry does not exist

fix
```
ERROR: failed to solve: failed to push kufu-ai/gocat:latest: push access denied, repository does not exist or may require authorization: server message: insufficient_scope: authorization failed
```


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Docker image push failure was fixed by introducing a new environment variable `DOCKERHUB_REPO_OWNER`.
- The image ID construction was updated to use the new `DOCKERHUB_REPO_OWNER` variable instead of `github.repository_owner`.
- These changes ensure the correct repository owner is used for Docker image operations.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Fix Docker image push by updating repository owner configuration</code></dd></summary>
<hr>

.github/workflows/docker-publish.yml

<li>Added <code>DOCKERHUB_REPO_OWNER</code> environment variable.<br> <li> Changed image ID construction to use <code>DOCKERHUB_REPO_OWNER</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/kufu-ai/gocat/pull/1139/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

