### PR TITLE
Hide projects without locked phases on describe-locks

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -314,13 +314,17 @@ func (s *SlackListener) describeLocks() slack.MsgOption {
 
 	var buf strings.Builder
 	for _, pj := range projects {
-		project := pj.Name
-		envs := pj.Phases
-		buf.WriteString(project)
-		buf.WriteString("\n")
-		for _, lock := range envs {
+		var wroteProjectHeader bool
+		for _, lock := range pj.Phases {
 			if !lock.Locked {
 				continue
+			}
+
+			if !wroteProjectHeader {
+				project := pj.Name
+				buf.WriteString(project)
+				buf.WriteString("\n")
+				wroteProjectHeader = true
 			}
 
 			env := lock.Name

--- a/slack_test.go
+++ b/slack_test.go
@@ -379,7 +379,6 @@ myproject2
 	}))
 	require.Equal(t, `myproject1
   staging: Locked (by user2, for deployment of revision b)
-myproject2
 `, nextMessage().Text())
 }
 


### PR DESCRIPTION
We made it hide unlocked phases in #1138.
This enhances it further by hiding the entire project if all the phases inside it are unlocked.