### PR TITLE
Enhance `@bot deploy` to respect locks

### DIFF
--- a/deploy/lock_test.go
+++ b/deploy/lock_test.go
@@ -94,7 +94,7 @@ func TestDescribeLocks(t *testing.T) {
 
 	require.NoError(t, c.Lock(ctx, "myproject1", "prod", "user1", "for deployment of revision a"))
 
-	locks, err := c.describeLocks(ctx)
+	locks, err := c.FetchLocks(ctx, "", "")
 	require.NoError(t, err)
 	require.Len(t, locks, 1)
 
@@ -114,7 +114,7 @@ func TestDescribeLocks(t *testing.T) {
 
 	require.NoError(t, c.Unlock(ctx, "myproject1", "prod", "user1", false))
 
-	locks, err = c.describeLocks(ctx)
+	locks, err = c.FetchLocks(ctx, "", "")
 	require.NoError(t, err)
 	require.Len(t, locks, 1)
 	require.Equal(t, map[string]Phase{

--- a/project.go
+++ b/project.go
@@ -152,6 +152,9 @@ func (p *ProjectList) Reload() {
 		pj.filterRegexp = cm.Data["FilterRegexp"]
 		pj.targetRegexp = cm.Data["TargetRegexp"]
 		pj.funcName = cm.Data["FuncName"]
+		// Note that, although this is named Alias, it is actually treated as a
+		// mandatory ID of the project, which is used to identify the project.
+		// to be deployed in some places.
 		pj.Alias = cm.Data["Alias"]
 		pj.DisableBranchDeploy = cm.Data["DisableBranchDeploy"] == "true"
 		if err := yaml.Unmarshal([]byte(cm.Data["Steps"]), &pj.steps); err != nil {


### PR DESCRIPTION
We recently added `@bot lock`, `@bot unlock`, and `@bot describe-locks` to handle deployment locks.

This finally enhances the existing `@bot deploy` command to consider locks. A deployment fails if the deployment target (project phase) has been locked by anyone else.