### PR TITLE
Add CONFIG_NAMESPACE and CONFIG_LOCKS_CONFIGMAP_NAME

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"sync"
 
 	"github.com/slack-go/slack"
+	"github.com/zaiminc/gocat/deploy"
 )
 
 func main() {
@@ -45,7 +45,7 @@ func main() {
 		projectList:       &projectList,
 		userList:          &userList,
 		interactorFactory: &interactorFactory,
-		mu:                &sync.Mutex{},
+		coordinator:       deploy.NewCoordinator(config.Namespace, config.LocksConfigMapName),
 	})
 	http.Handle("/interaction", interactionHandler{
 		verificationToken: config.SlackVerificationToken,

--- a/config.go
+++ b/config.go
@@ -21,6 +21,10 @@ type CatConfig struct {
 	JenkinsJobToken        string
 	ArgoCDHost             string
 	EnableAutoDeploy       bool // optional (default: false)
+
+	// For deploy.Coordinator
+	Namespace          string
+	LocksConfigMapName string
 }
 
 func findRepositoryName(repo string) string {
@@ -59,6 +63,15 @@ func InitConfig() (*CatConfig, error) {
 	Config.ManifestRepositoryOrg = findRepositoryOrg(Config.ManifestRepository)
 	if Config.GitHubUserName == "" {
 		Config.GitHubUserName = "gocat"
+	}
+
+	Config.Namespace = os.Getenv("CONFIG_NAMESPACE")
+	if Config.Namespace == "" {
+		log.Printf("[WARNING] CONFIG_NAMESPACE environment variable is not set. Lock-related features will not work.")
+	}
+	Config.LocksConfigMapName = os.Getenv("CONFIG_LOCKS_CONFIGMAP_NAME")
+	if Config.LocksConfigMapName == "" {
+		log.Printf("[WARNING] CONFIG_LOCKS_CONFIGMAP_NAME environment variable is not set. Lock-related features will not work.")
 	}
 
 	switch os.Getenv("SECRET_STORE") {

--- a/slack_test.go
+++ b/slack_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"sync"
 	"testing"
 	"time"
 
@@ -230,7 +229,7 @@ func TestSlackLockUnlock(t *testing.T) {
 		projectList:       &projectList,
 		userList:          &userList,
 		interactorFactory: &interactorFactory,
-		mu:                &sync.Mutex{},
+		coordinator:       deploy.NewCoordinator("gocat", "deploylocks"),
 	}
 
 	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{


### PR DESCRIPTION
Add two environment variables to specify the namespace and the confimap to use lock-related features.

The namespace has been `gocat` but we no longer have the default. You need to explicitly specify the namespace, using the downward API, for example.

Similarly, the configmap name has been `deploylocks`, but we have no default value anymore. Specify it, like CONFIG_LOCKS_CONFIGMAP_NAME=deploylocks, for example to retain the default behavior.