### PR TITLE
change docker hub user

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,7 +16,7 @@ on:
 env:
   # TODO: Change variable to your image's name.
   IMAGE_NAME: gocat
-  DOCKERHUB_USER: yasukexxx
+  DOCKERHUB_USER: 073722781018412843238584254322
   PLATFORMS: linux/arm64,linux/amd64
   DOCKERHUB_REPO_OWNER: davinci-std
 


### PR DESCRIPTION
### **User description**
fix CI fail

```
Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password
Error: Process completed with exit code 1.
```


___

### **PR Type**
configuration changes


___

### **Description**
- GitHub Actionsのワークフローで使用されるDocker Hubユーザー名を`yasukexxx`から`073722781018412843238584254322`に変更しました。
- この変更により、CIの失敗を修正します。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Update Docker Hub user in GitHub Actions workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/docker-publish.yml

<li>Docker Hub user changed from <code>yasukexxx</code> to <br><code>073722781018412843238584254322</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/kufu-ai/gocat/pull/1145/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information