### PR TITLE
fix invalid DOCKERHUB_USER and REPO_OWNER

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -16,9 +16,9 @@ on:
 env:
   # TODO: Change variable to your image's name.
   IMAGE_NAME: gocat
-  DOCKERHUB_USER: 073722781018412843238584254322
+  DOCKERHUB_USER: zaimbot
   PLATFORMS: linux/arm64,linux/amd64
-  DOCKERHUB_REPO_OWNER: davinci-std
+  DOCKERHUB_REPO_OWNER: zaiminc
 
 jobs:
   # Run tests.


### PR DESCRIPTION
### **User description**
fix

```
Error response from daemon: Get "https://registry-1.docker.io/v2/": unauthorized: incorrect username or password
Error: Process completed with exit code 1.
```


___

### **PR Type**
configuration changes


___

### **Description**
- DockerHubのユーザー名とリポジトリオーナーを更新しました。これにより、認証エラーが解決されることを期待しています。
- `DOCKERHUB_USER`を`zaimbot`に変更しました。
- `DOCKERHUB_REPO_OWNER`を`zaiminc`に変更しました。


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-publish.yml</strong><dd><code>Update DockerHub user and repository owner in workflow configuration</code></dd></summary>
<hr>

.github/workflows/docker-publish.yml

<li><code>DOCKERHUB_USER</code> changed from <code>073722781018412843238584254322</code> to <code>zaimbot</code>.<br> <li> <code>DOCKERHUB_REPO_OWNER</code> changed from <code>davinci-std</code> to <code>zaiminc</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/kufu-ai/gocat/pull/1146/files#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information