### PR TITLE
add configmap create update permissions

### DIFF
--- a/manifests/manifest.yaml
+++ b/manifests/manifest.yaml
@@ -53,6 +53,13 @@ rules:
 - apiGroups: [""]
   resources:
   - configmaps
+  verbs:
+  - "get"
+  - "list"
+  - "update"
+  - "create"
+- apiGroups: [""]
+  resources:
   - jobs
   verbs:
   - "get"


### PR DESCRIPTION
### **Description**
This pull request adds permissions for creating and updating ConfigMaps to the existing gocat-role ClusterRole in our Kubernetes cluster. These changes ensure that the necessary actions on ConfigMaps can be performed by users or services with this role.

### **Related Application Change**
This permissions update is necessary due to a recent change in our application, where ConfigMaps are created and updated dynamically. Please refer to the following pull request for the specific application changes: #1121