### PR TITLE
Fix `@bot describe locks` to get triggered

### DIFF
--- a/slackcmd/parse.go
+++ b/slackcmd/parse.go
@@ -84,7 +84,7 @@ func parseLockUnlock(text string) (Command, error) {
 }
 
 func parseDescribeLocks(text string) (Command, error) {
-	if text != "describe locks" {
+	if !strings.Contains(text, "describe locks") {
 		return nil, patternError("describe locks")
 	}
 


### PR DESCRIPTION
This mainly fixes `parseDescribeLocks` in the implementation to make `describe locks` actually usable.

Previously, the command has never been triggered when you say `@bot describe-locks`, because the function was not taking into account that mentions to the bot contains text prefixed by the bot user ID.

This PR also tweaks the test so that test data contains the bot user ID as prefixes in the mentioned texts, along with adding support for CONFIG_NAMESPACE in the test, allowing you to configure which k8s namespace to use in the test.