### PR TITLE
Do respond on invalid command

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -196,6 +196,11 @@ func (s *SlackListener) handleMessageEvent(ev *slackevents.AppMentionEvent) erro
 		log.Printf("[INFO] %s command is Called", cmd.Name())
 		return s.runCommand(cmd, ev.User, ev.Channel)
 	}
+
+	if _, _, err := s.client.PostMessage(ev.Channel, s.errorMessage("Invalid command. Say `@bot help` to see the usage guide")); err != nil {
+		log.Println("[INFO] invalid command", ev.Text)
+	}
+
 	return nil
 }
 

--- a/slack_test.go
+++ b/slack_test.go
@@ -268,6 +268,13 @@ func TestSlackLockUnlock(t *testing.T) {
 	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
 		User:    "U1234",
 		Channel: "C1234",
+		Text:    "<@U0LAN0Z89> lock myproject1 production",
+	}))
+	require.Equal(t, "Invalid command. Say `@bot help` to see the usage guide", nextMessage().Text())
+
+	require.NoError(t, l.handleMessageEvent(&slackevents.AppMentionEvent{
+		User:    "U1234",
+		Channel: "C1234",
 		Text:    "<@U0LAN0Z89> lock myproject1 production for deployment of revision a",
 	}))
 	require.Equal(t, "Locked myproject1 production", nextMessage().Text())


### PR DESCRIPTION
gocat had been silently ignoring the command if it was not recognized, which resulted in users being confused because they couldn't tell which was wrong, gocat or the user.

This improves gocat, so that it does respond on invalid command, so that the user can know the command was indeed wrong, and is instructed to run `@bot help` to see the correct usage.