### PR TITLE
Support for apps-specific GitHub organization

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -17,6 +17,8 @@ type slackConfig struct {
 	JenkinsJobToken     string `json:"JENKINS_JOB_TOKEN"`
 	GitHubBotUserToken  string `json:"GITHUB_BOT_USER_TOKEN"`
 	ArgoCDHost          string `json:"ARGOCD_HOST"`
+
+	AppRepositoryGitHubAccessToken string `json:"APP_REPOSITORY_GITHUB_ACCESS_TOKEN"`
 }
 
 // getSecret fetches slackConfig from AWS Secrets Manager secret

--- a/auth.go
+++ b/auth.go
@@ -21,14 +21,12 @@ type slackConfig struct {
 	AppRepositoryGitHubAccessToken string `json:"APP_REPOSITORY_GITHUB_ACCESS_TOKEN"`
 }
 
-// getSecret fetches slackConfig from AWS Secrets Manager secret
-// denoted by secretName.
-// The secret must be a JSON object with the keys defined in slackConfig.
-func getSecret(secretName string) (*slackConfig, error) {
-	//Create a Secrets Manager client
+// getSecretValue fetches the value of a secret from AWS Secrets Manager.
+func getSecretValue(secretName string) (*secretsmanager.GetSecretValueOutput, error) {
+	// Create a Secrets Manager client
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String("ap-northeast-1")},
-	)
+		Region: aws.String("ap-northeast-1"),
+	})
 	if err != nil {
 		log.Print("Error creating session", err)
 		return nil, err
@@ -71,6 +69,18 @@ func getSecret(secretName string) (*slackConfig, error) {
 			// Message from an error.
 			log.Print(err.Error())
 		}
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// getSlackConfigFromSecret fetches slackConfig from AWS Secrets Manager secret
+// denoted by secretName.
+// The secret must be a JSON object with the keys defined in slackConfig.
+func getSlackConfigFromSecret(getSecretValue func(string) (*secretsmanager.GetSecretValueOutput, error), secretName string) (*slackConfig, error) {
+	result, err := getSecretValue(secretName)
+	if err != nil {
 		return nil, err
 	}
 

--- a/bot.go
+++ b/bot.go
@@ -20,7 +20,9 @@ func main() {
 		config.SlackOAuthToken,
 		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
 	)
-	github := CreateGitHubInstance("", config.GitHubAccessToken, config.ManifestRepositoryOrg, config.ManifestRepositoryName, config.GitHubDefaultBranch)
+	github := CreateGitHubInstance("", config.GitHubAccessToken, config.ManifestRepositoryOrg, config.ManifestRepositoryName, config.GitHubDefaultBranch,
+		config,
+	)
 	git := CreateGitOperatorInstance(
 		config.GitHubUserName,
 		config.GitHubAccessToken,

--- a/config.go
+++ b/config.go
@@ -76,42 +76,46 @@ func findRepositoryOrg(repo string) string {
 }
 
 func InitConfig() (*CatConfig, error) {
+	return initConfig(os.Getenv)
+}
+
+func initConfig(getenv func(string) string) (*CatConfig, error) {
 	configEnvs := []string{"CONFIG_MANIFEST_REPOSITORY"}
 	for _, configEnv := range configEnvs {
-		if os.Getenv(configEnv) == "" {
+		if getenv(configEnv) == "" {
 			return nil, fmt.Errorf("Set %s environment variable", configEnv)
 		}
 	}
 	var Config = &CatConfig{}
-	Config.ManifestRepository = os.Getenv("CONFIG_MANIFEST_REPOSITORY")
-	Config.EnableAutoDeploy = os.Getenv("CONFIG_ENABLE_AUTO_DEPLOY") == "true"
-	Config.ArgoCDHost = os.Getenv("CONFIG_ARGOCD_HOST")
-	Config.JenkinsHost = os.Getenv("CONFIG_JENKINS_HOST")
-	Config.GitHubUserName = os.Getenv("CONFIG_GITHUB_USER_NAME")
-	Config.GitHubDefaultBranch = os.Getenv("CONFIG_GITHUB_DEFAULT_BRANCH")
+	Config.ManifestRepository = getenv("CONFIG_MANIFEST_REPOSITORY")
+	Config.EnableAutoDeploy = getenv("CONFIG_ENABLE_AUTO_DEPLOY") == "true"
+	Config.ArgoCDHost = getenv("CONFIG_ARGOCD_HOST")
+	Config.JenkinsHost = getenv("CONFIG_JENKINS_HOST")
+	Config.GitHubUserName = getenv("CONFIG_GITHUB_USER_NAME")
+	Config.GitHubDefaultBranch = getenv("CONFIG_GITHUB_DEFAULT_BRANCH")
 	Config.ManifestRepositoryName = findRepositoryName(Config.ManifestRepository)
 	Config.ManifestRepositoryOrg = findRepositoryOrg(Config.ManifestRepository)
-	Config.AppRepositoryOrg = os.Getenv("CONFIG_APP_REPOSITORY_ORG")
+	Config.AppRepositoryOrg = getenv("CONFIG_APP_REPOSITORY_ORG")
 	if Config.GitHubUserName == "" {
 		Config.GitHubUserName = "gocat"
 	}
 
-	Config.Namespace = os.Getenv("CONFIG_NAMESPACE")
+	Config.Namespace = getenv("CONFIG_NAMESPACE")
 	if Config.Namespace == "" {
 		log.Printf("[WARNING] CONFIG_NAMESPACE environment variable is not set. Lock-related features will not work.")
 	}
-	Config.LocksConfigMapName = os.Getenv("CONFIG_LOCKS_CONFIGMAP_NAME")
+	Config.LocksConfigMapName = getenv("CONFIG_LOCKS_CONFIGMAP_NAME")
 	if Config.LocksConfigMapName == "" {
 		log.Printf("[WARNING] CONFIG_LOCKS_CONFIGMAP_NAME environment variable is not set. Lock-related features will not work.")
 	}
 
-	switch os.Getenv("SECRET_STORE") {
+	switch getenv("SECRET_STORE") {
 	case "aws/secrets-manager":
 		log.Print("Using aws/secrets-manager as secret store. Set SECRET_STORE env if you want to use another secret store")
-		if os.Getenv("SECRET_NAME") == "" {
+		if getenv("SECRET_NAME") == "" {
 			return nil, fmt.Errorf("Set SECRET_NAME environment variable")
 		}
-		secret, err := getSecret(os.Getenv("SECRET_NAME"))
+		secret, err := getSecret(getenv("SECRET_NAME"))
 		if err != nil {
 			return nil, fmt.Errorf("unable to get secret: %w", err)
 		}
@@ -127,16 +131,16 @@ func InitConfig() (*CatConfig, error) {
 		log.Print("Using env as secret store. Set SECRET_STORE env if you want to use another secret store")
 		envs := []string{"CONFIG_GITHUB_ACCESS_TOKEN", "CONFIG_SLACK_OAUTH_TOKEN", "CONFIG_SLACK_VERIFICATION_TOKEN", "CONFIG_JENKINS_BOT_TOKEN", "CONFIG_JENKINS_JOB_TOKEN"}
 		for _, env := range envs {
-			if os.Getenv(env) == "" {
+			if getenv(env) == "" {
 				log.Printf("[WARNING] %s environment variable is Empty", env)
 			}
 		}
-		Config.GitHubAccessToken = os.Getenv("CONFIG_GITHUB_ACCESS_TOKEN")
-		Config.AppRepositoryGitHubAccessToken = os.Getenv("CONFIG_APP_REPOSITORY_GITHUB_ACCESS_TOKEN")
-		Config.SlackOAuthToken = os.Getenv("CONFIG_SLACK_OAUTH_TOKEN")
-		Config.SlackVerificationToken = os.Getenv("CONFIG_SLACK_VERIFICATION_TOKEN")
-		Config.JenkinsBotToken = os.Getenv("CONFIG_JENKINS_BOT_TOKEN")
-		Config.JenkinsJobToken = os.Getenv("CONFIG_JENKINS_JOB_TOKEN")
+		Config.GitHubAccessToken = getenv("CONFIG_GITHUB_ACCESS_TOKEN")
+		Config.AppRepositoryGitHubAccessToken = getenv("CONFIG_APP_REPOSITORY_GITHUB_ACCESS_TOKEN")
+		Config.SlackOAuthToken = getenv("CONFIG_SLACK_OAUTH_TOKEN")
+		Config.SlackVerificationToken = getenv("CONFIG_SLACK_VERIFICATION_TOKEN")
+		Config.JenkinsBotToken = getenv("CONFIG_JENKINS_BOT_TOKEN")
+		Config.JenkinsJobToken = getenv("CONFIG_JENKINS_JOB_TOKEN")
 		return Config, nil
 	}
 }

--- a/config.go
+++ b/config.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"os"
 	"regexp"
+
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
 type CatConfig struct {
@@ -76,10 +78,10 @@ func findRepositoryOrg(repo string) string {
 }
 
 func InitConfig() (*CatConfig, error) {
-	return initConfig(os.Getenv)
+	return initConfig(getSecretValue, os.Getenv)
 }
 
-func initConfig(getenv func(string) string) (*CatConfig, error) {
+func initConfig(getSecretValue func(string) (*secretsmanager.GetSecretValueOutput, error), getenv func(string) string) (*CatConfig, error) {
 	configEnvs := []string{"CONFIG_MANIFEST_REPOSITORY"}
 	for _, configEnv := range configEnvs {
 		if getenv(configEnv) == "" {
@@ -115,7 +117,7 @@ func initConfig(getenv func(string) string) (*CatConfig, error) {
 		if getenv("SECRET_NAME") == "" {
 			return nil, fmt.Errorf("Set SECRET_NAME environment variable")
 		}
-		secret, err := getSecret(getenv("SECRET_NAME"))
+		secret, err := getSlackConfigFromSecret(getSecretValue, getenv("SECRET_NAME"))
 		if err != nil {
 			return nil, fmt.Errorf("unable to get secret: %w", err)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigInitGet(t *testing.T) {
+	type testcase struct {
+		subject                string
+		env                    map[string]string
+		secrets                map[string]string
+		want                   CatConfig
+		wantAppRepositoryOrg   string
+		wantAppRepositoryToken string
+	}
+
+	secrets := map[string]string{
+		"mysecret": `{
+  "GITHUB_BOT_USER_TOKEN": "mysecret_token",
+  "APP_REPOSITORY_GITHUB_ACCESS_TOKEN": "mysecret_apptoken"
+}`,
+	}
+
+	tcs := []testcase{
+		{
+			subject: "minimal",
+			env: map[string]string{
+				"CONFIG_MANIFEST_REPOSITORY": "https://github.com/org/manifests.git",
+				"CONFIG_GITHUB_ACCESS_TOKEN": "mytoken",
+			},
+			secrets: secrets,
+			want: CatConfig{
+				ManifestRepository:     "https://github.com/org/manifests.git",
+				ManifestRepositoryName: "manifests",
+				ManifestRepositoryOrg:  "org",
+				GitHubAccessToken:      "mytoken",
+				GitHubUserName:         "gocat",
+			},
+			wantAppRepositoryOrg:   "org",
+			wantAppRepositoryToken: "mytoken",
+		},
+		{
+			subject: "with app org and token",
+			env: map[string]string{
+				"CONFIG_MANIFEST_REPOSITORY":                "https://github.com/org/manifests.git",
+				"CONFIG_GITHUB_ACCESS_TOKEN":                "mytoken",
+				"CONFIG_APP_REPOSITORY_ORG":                 "apporg",
+				"CONFIG_APP_REPOSITORY_GITHUB_ACCESS_TOKEN": "apptoken",
+			},
+			secrets: secrets,
+			want: CatConfig{
+				ManifestRepository:             "https://github.com/org/manifests.git",
+				ManifestRepositoryName:         "manifests",
+				ManifestRepositoryOrg:          "org",
+				GitHubAccessToken:              "mytoken",
+				GitHubUserName:                 "gocat",
+				AppRepositoryOrg:               "apporg",
+				AppRepositoryGitHubAccessToken: "apptoken",
+			},
+			wantAppRepositoryOrg:   "apporg",
+			wantAppRepositoryToken: "apptoken",
+		},
+		{
+			subject: "with secrets",
+			env: map[string]string{
+				"CONFIG_MANIFEST_REPOSITORY":                "https://github.com/org/manifests.git",
+				"CONFIG_GITHUB_ACCESS_TOKEN":                "mytoken",
+				"CONFIG_APP_REPOSITORY_ORG":                 "apporg",
+				"CONFIG_APP_REPOSITORY_GITHUB_ACCESS_TOKEN": "apptoken",
+				"SECRET_STORE":                              "aws/secrets-manager",
+				"SECRET_NAME":                               "mysecret",
+			},
+			secrets: secrets,
+			want: CatConfig{
+				ManifestRepository:             "https://github.com/org/manifests.git",
+				ManifestRepositoryName:         "manifests",
+				ManifestRepositoryOrg:          "org",
+				GitHubAccessToken:              "mysecret_token",
+				GitHubUserName:                 "gocat",
+				AppRepositoryOrg:               "apporg",
+				AppRepositoryGitHubAccessToken: "mysecret_apptoken",
+			},
+			wantAppRepositoryOrg:   "apporg",
+			wantAppRepositoryToken: "mysecret_apptoken",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.subject, func(t *testing.T) {
+			c, err := initConfig(func(secretName string) (*secretsmanager.GetSecretValueOutput, error) {
+				return &secretsmanager.GetSecretValueOutput{
+					SecretString: aws.String(tc.secrets[secretName]),
+				}, nil
+			}, func(s string) string {
+				return tc.env[s]
+			})
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.want, *c, "CatConfig")
+			assert.Equal(t, tc.wantAppRepositoryOrg, c.GetAppRepositoryOrg(), "AppRepositoryOrg")
+			assert.Equal(t, tc.wantAppRepositoryToken, c.GetAppRepositoryGitHubAccessToken(), "AppRepositoryGitHubAccessToken")
+		})
+	}
+}

--- a/doc/env.md
+++ b/doc/env.md
@@ -6,6 +6,7 @@
 |SECRET_NAME | Set Secrets Manager name if you set SECRET_STORE. |false|
 |CONFIG_MANIFEST_REPOSITORY| Manifest repository (like `https://github.com/xxx/xxx.git`) |false|
 |CONFIG_MANIFEST_REPOSITORY_ORG| Organization of manifest repository (like `zaiminc`)|false|
+|APP_REPOSITORY_ORG | Set GitHub organization of the app repositories. Note it's used for listing branches | Defaults to the organization of the manifest repository |
 |CONFIG_ARGOCD_HOST| Set your ArgoCD host. |false|
 |CONFIG_JENKINS_HOST| Set your Jenkins host. |false|
 |CONFIG_NAMESPACE| Set ConfigMap namespace |false|
@@ -20,6 +21,7 @@ To use AWS Secrets Manager, set SECRET_STORE env to `aws/secrets-manager`.
 |SLACK_BOT_OAUTH_TOKEN| Bot User OAuth Access Token |true|
 |SLACK_BOT_API_VERIFICATION_TOKEN|Verification Token |true|
 |GITHUB_BOT_USER_TOKEN| Set GitHub personal access token if your deploy with GitOps. |false|
+|APP_REPOSITORY_GITHUB_ACCESS_TOKEN | Set GitHub personal access token for accessing app repositories. | Defaults to GITHUB_BOT_USER_TOKEN |
 |JENKINS_BOT_USER_TOKEN| Set Jenkins token if you deploy through Jenkins. |false|
 |JENKINS_JOB_TOKEN| Set Jenkins token if you deploy through Jenkins.|false|
 

--- a/github.go
+++ b/github.go
@@ -29,6 +29,9 @@ type GitHub struct {
 	org           string
 	repo          string
 	defaultBranch string
+
+	appOrg    string
+	appClient githubv4.Client
 }
 
 type GitHubInput struct {
@@ -36,7 +39,13 @@ type GitHubInput struct {
 	Branch     string
 }
 
-func CreateGitHubInstance(url, token, org, repo, defaultBranch string) GitHub {
+// appRepositoryAccess provides the interface to get the app repository org and GitHub access token.
+type appRepositoryAccess interface {
+	GetAppRepositoryOrg() string
+	GetAppRepositoryGitHubAccessToken() string
+}
+
+func CreateGitHubInstance(url, token, org, repo, defaultBranch string, appRepoAccess appRepositoryAccess) GitHub {
 	src := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},
 	)
@@ -48,7 +57,23 @@ func CreateGitHubInstance(url, token, org, repo, defaultBranch string) GitHub {
 	} else {
 		client = githubv4.NewClient(httpClient)
 	}
-	return GitHub{*client, httpClient, org, repo, defaultBranch}
+
+	var appClient *githubv4.Client
+	{
+		appSrc := oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: appRepoAccess.GetAppRepositoryGitHubAccessToken()},
+		)
+		appHTTPClient := oauth2.NewClient(context.Background(), appSrc)
+		if url != "" {
+			appClient = githubv4.NewEnterpriseClient(url, appHTTPClient)
+		} else {
+			appClient = githubv4.NewClient(appHTTPClient)
+		}
+	}
+	return GitHub{*client, httpClient, org, repo, defaultBranch,
+		appRepoAccess.GetAppRepositoryOrg(),
+		*appClient,
+	}
 }
 
 func (g GitHub) GetFile(path string) (b []byte, err error) {
@@ -119,10 +144,10 @@ func (g GitHub) ListBranch(name string) ([]string, error) {
 	}
 	variables := map[string]interface{}{
 		"name": githubv4.String(name),
-		"org":  githubv4.String(g.org),
+		"org":  githubv4.String(g.appOrg),
 	}
 
-	err := g.client.Query(context.Background(), &query, variables)
+	err := g.appClient.Query(context.Background(), &query, variables)
 	if err != nil {
 		return []string{}, err
 	}

--- a/slack_test.go
+++ b/slack_test.go
@@ -201,6 +201,7 @@ func TestSlackLockUnlock(t *testing.T) {
 		config.ManifestRepositoryOrg,
 		config.ManifestRepositoryName,
 		config.GitHubDefaultBranch,
+		config,
 	)
 	git := CreateGitOperatorInstance(
 		config.GitHubUserName,


### PR DESCRIPTION
This introduces `CONFIG_APP_REPOSITORY_ORG` for letting gocat to use look for project (or application) repositories in a separate organization than one specified via `CONFIG_MANIFEST_REPOSITORY`.

Let's say you had a manifest repository at `org1/manifests` and project repository like `org2/app1`:

- org1
  - manifests (CONFIG_MANIFEST_REPOSITORY=org1/manifests)
- org2 (You create a proj configmap for each app repository under this org)
  - app1
  - app2
  - ...
  - appN

This looks very straight-forward, right? But gocat was unable to handle this setup.

More concretely, previously, gocat's `branch-list` failed with a cryptic error, because you can only set `app1` instead of the entire `org2/app1` as the project repository to fetch branches from, resulting in `gocat` trying to fetch an inexistent repository `org1/app1`.

This feature fixes it by allowing you to set `CONFIG_APP_REPOSITORY_ORG=org2` along with the existing `CONFIG_MANIFEST_REPOSITORY=org1/manifests`:

- org1
  - manifests (CONFIG_MANIFEST_REPOSITORY=org1/manifests)
- org2 (CONFIG_APP_REPOSITORY_ORG=org2)
  - app1
  - app2
  - ...
  - appN

Lastly, I've also added `APP_REPOSITORY_GITHUB_ACCESS_TOKEN` so you can specify another GitHub token dedicated for accessing the app repository org. It could be handy for restring scopes of tokens for security reasons and/or minimizing blast radius.