### PR TITLE
Refactor and test `describe locks` output format

### DIFF
--- a/deploy/format.go
+++ b/deploy/format.go
@@ -1,0 +1,38 @@
+package deploy
+
+import "strings"
+
+func FormatProjectDescs(projects []ProjectDesc) string {
+	var buf strings.Builder
+	for _, pj := range projects {
+		var wroteProjectHeader bool
+		for _, lock := range pj.Phases {
+			if !lock.Locked {
+				continue
+			}
+
+			if !wroteProjectHeader {
+				project := pj.Name
+				buf.WriteString(project)
+				buf.WriteString("\n")
+				wroteProjectHeader = true
+			}
+
+			env := lock.Name
+			buf.WriteString("  ")
+			buf.WriteString(env)
+			buf.WriteString(": ")
+			buf.WriteString("Locked")
+			if len(lock.LockHistory) > 0 {
+				buf.WriteString(" (by ")
+				buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].User)
+				buf.WriteString(", for ")
+				buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].Reason)
+				buf.WriteString(")")
+			}
+			buf.WriteString("\n")
+		}
+	}
+
+	return buf.String()
+}

--- a/deploy/format_test.go
+++ b/deploy/format_test.go
@@ -25,10 +25,28 @@ func TestFormatProjectDescs(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "myproject1-api",
+			Phases: []PhaseDesc{
+				{
+					Name: "staging",
+					Phase: Phase{
+						Locked: true,
+						LockHistory: []LockHistoryItem{
+							{
+								User:   "user2",
+								Reason: "for deployment of revision b",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	require.Equal(t, `myproject1
   prod: Locked (by user1, for for deployment of revision a)
+myproject1-api
+  staging: Locked (by user2, for for deployment of revision b)
 `, FormatProjectDescs(projects))
-
 }

--- a/deploy/format_test.go
+++ b/deploy/format_test.go
@@ -42,11 +42,27 @@ func TestFormatProjectDescs(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "myproject2",
+			Phases: []PhaseDesc{
+				{
+					Name: "prod",
+					Phase: Phase{
+						Locked: true,
+						// There should be 1 or more LockHistoryItem if Locked is true.
+						// But we intentionally omit it here to test the case where
+						// some bug causes LockHistoryItem to be empty.
+					},
+				},
+			},
+		},
 	}
 
 	require.Equal(t, `myproject1
   prod: Locked (by user1, for for deployment of revision a)
 myproject1-api
   staging: Locked (by user2, for for deployment of revision b)
+myproject2
+  prod: Locked
 `, FormatProjectDescs(projects))
 }

--- a/deploy/format_test.go
+++ b/deploy/format_test.go
@@ -1,0 +1,34 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatProjectDescs(t *testing.T) {
+	projects := []ProjectDesc{
+		{
+			Name: "myproject1",
+			Phases: []PhaseDesc{
+				{
+					Name: "prod",
+					Phase: Phase{
+						Locked: true,
+						LockHistory: []LockHistoryItem{
+							{
+								User:   "user1",
+								Reason: "for deployment of revision a",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	require.Equal(t, `myproject1
+  prod: Locked (by user1, for for deployment of revision a)
+`, FormatProjectDescs(projects))
+
+}

--- a/deploy/format_test.go
+++ b/deploy/format_test.go
@@ -56,6 +56,17 @@ func TestFormatProjectDescs(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "myproject3",
+			Phases: []PhaseDesc{
+				{
+					Name: "staging",
+					Phase: Phase{
+						Locked: false,
+					},
+				},
+			},
+		},
 	}
 
 	require.Equal(t, `myproject1

--- a/slack.go
+++ b/slack.go
@@ -335,38 +335,9 @@ func (s *SlackListener) describeLocks() slack.MsgOption {
 		return s.errorMessage(err.Error())
 	}
 
-	var buf strings.Builder
-	for _, pj := range projects {
-		var wroteProjectHeader bool
-		for _, lock := range pj.Phases {
-			if !lock.Locked {
-				continue
-			}
+	msg := deploy.FormatProjectDescs(projects)
 
-			if !wroteProjectHeader {
-				project := pj.Name
-				buf.WriteString(project)
-				buf.WriteString("\n")
-				wroteProjectHeader = true
-			}
-
-			env := lock.Name
-			buf.WriteString("  ")
-			buf.WriteString(env)
-			buf.WriteString(": ")
-			buf.WriteString("Locked")
-			if len(lock.LockHistory) > 0 {
-				buf.WriteString(" (by ")
-				buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].User)
-				buf.WriteString(", for ")
-				buf.WriteString(lock.LockHistory[len(lock.LockHistory)-1].Reason)
-				buf.WriteString(")")
-			}
-			buf.WriteString("\n")
-		}
-	}
-
-	return s.infoMessage(buf.String())
+	return s.infoMessage(msg)
 }
 
 func (s *SlackListener) checkDeploymentLock(projectID, env string, triggeredBy string, replyIn string) (slack.MsgOption, bool) {


### PR DESCRIPTION
We have a known bug where projects containing hyphens in their names are incorrectly formatted in the `describe locks` output.
This pull request refactors and test a part of the suspicious code to spot where the bug is.
Apparently, the formatting code is fine!