### PR TITLE
Fix describe locks bug

### DIFF
--- a/deploy/configmap.go
+++ b/deploy/configmap.go
@@ -68,8 +68,8 @@ func configMapKey(project, environment string) string {
 }
 
 func splitConfigMapKey(key string) (string, string) {
-	parts := strings.Split(key, Sep)
-	return parts[0], parts[1]
+	i := strings.LastIndex(key, Sep)
+	return key[:i], key[i+1:]
 }
 
 func (c *Coordinator) getOrCreateConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {

--- a/deploy/configmap.go
+++ b/deploy/configmap.go
@@ -63,7 +63,7 @@ const (
 
 // configMapKey is a helper function that returns the key within the ConfigMap for the project and the environment
 // which is either locked or unlocked.
-func (c *Coordinator) configMapKey(project, environment string) string {
+func configMapKey(project, environment string) string {
 	return project + Sep + environment
 }
 

--- a/deploy/lock_encoding.go
+++ b/deploy/lock_encoding.go
@@ -1,0 +1,109 @@
+package deploy
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type keysAndValuesEncoding struct {
+	data map[string]string
+}
+
+func (e *keysAndValuesEncoding) lock(project, environment, user, reason string, at metav1.Time) error {
+	key := configMapKey(project, environment)
+	value, err := strToConfigMapValue(e.data[key])
+	if err != nil {
+		return fmt.Errorf("unable to unmarshal str into value: %w", err)
+	}
+
+	if value.Locked {
+		return ErrAlreadyLocked
+	}
+
+	if n := len(value.LockHistory); n >= MaxHistoryItems {
+		value.LockHistory = value.LockHistory[n-MaxHistoryItems+1:]
+	}
+
+	value.LockHistory = append(value.LockHistory, LockHistoryItem{
+		User:   user,
+		Action: LockActionLock,
+		At:     at,
+		Reason: reason,
+	})
+
+	value.Locked = true
+
+	e.data[key], err = configMapValueToStr(value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *keysAndValuesEncoding) unlock(project, environment, user string, force bool, at metav1.Time) error {
+	key := configMapKey(project, environment)
+	value, err := strToConfigMapValue(e.data[key])
+	if err != nil {
+		return err
+	}
+
+	if !value.Locked {
+		return ErrAlreadyUnlocked
+	}
+
+	if force {
+		value.Locked = false
+	} else {
+		if len(value.LockHistory) == 0 || value.LockHistory[len(value.LockHistory)-1].User != user {
+			return newNotAllowedToUnlockError(user)
+		}
+
+		if n := len(value.LockHistory); n >= MaxHistoryItems {
+			value.LockHistory = value.LockHistory[n-MaxHistoryItems+1:]
+		}
+
+		value.Locked = false
+		value.LockHistory = append(value.LockHistory, LockHistoryItem{
+			User:   user,
+			Action: LockActionUnlock,
+			At:     at,
+		})
+	}
+
+	e.data[key], err = configMapValueToStr(value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (e *keysAndValuesEncoding) describeLocks(projectFilter, phaseFilter string) (map[string]map[string]Phase, error) {
+	locks := make(map[string]map[string]Phase)
+	for k, v := range e.data {
+		value, err := strToConfigMapValue(v)
+		if err != nil {
+			return nil, err
+		}
+
+		project, environment := splitConfigMapKey(k)
+
+		if projectFilter != "" && project != projectFilter {
+			continue
+		}
+
+		if phaseFilter != "" && environment != phaseFilter {
+			continue
+		}
+
+		if locks[project] == nil {
+			locks[project] = make(map[string]Phase)
+		}
+
+		locks[project][environment] = value
+	}
+
+	return locks, nil
+}

--- a/deploy/lock_encoding_test.go
+++ b/deploy/lock_encoding_test.go
@@ -1,0 +1,84 @@
+package deploy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestKeysAndValuesEncoding(t *testing.T) {
+	data := map[string]string{}
+	enc := &keysAndValuesEncoding{
+		data: data,
+	}
+
+	now, err := time.Parse(time.RFC3339, "2021-09-01T00:00:00Z")
+	require.NoError(t, err)
+
+	kNow := metav1.NewTime(now.Local())
+
+	require.NoError(t, enc.lock("myproject1", "prod", "user1", "for deployment of revision 1a", kNow))
+	require.ErrorIs(t, enc.lock("myproject1", "prod", "user1", "for deployment of revision 1b", kNow), ErrAlreadyLocked)
+	require.ErrorIs(t, enc.lock("myproject1", "prod", "user2", "for deployment of revision 1b", kNow), ErrAlreadyLocked)
+
+	require.ErrorIs(t, enc.unlock("myproject2", "prod", "user1", false, kNow), ErrAlreadyUnlocked)
+	require.NoError(t, enc.lock("myproject2", "prod", "user1", "for deployment of revision 2a", kNow))
+
+	require.NoError(t, enc.lock("myproject2-api", "prod", "user1", "for deployment of revision 3a", kNow))
+
+	locks, err := enc.describeLocks("", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]map[string]Phase{
+		"myproject1": {
+			"prod": {
+				Locked: true,
+				LockHistory: []LockHistoryItem{
+					{
+						User:   "user1",
+						Action: LockActionLock,
+						At:     kNow,
+						Reason: "for deployment of revision 1a",
+					},
+				},
+			},
+		},
+		"myproject2": {
+			"prod": {
+				Locked: true,
+				LockHistory: []LockHistoryItem{
+					{
+						User:   "user1",
+						Action: LockActionLock,
+						At:     kNow,
+						Reason: "for deployment of revision 2a",
+					},
+				},
+			},
+			// TODO There's a known bug where "myproject2-api/prod" are conflated as "myproject2/prod".
+			// },
+			// "myproject2-api": {
+			// 	"prod": {
+			"api": {
+				Locked: true,
+				LockHistory: []LockHistoryItem{
+					{
+						User:   "user1",
+						Action: LockActionLock,
+						At:     kNow,
+						Reason: "for deployment of revision 3a",
+					},
+				},
+			},
+		},
+	}, locks)
+
+	assert.Equal(t, map[string]string{
+		"myproject1-prod":     `{"locked":true,"lockHistory":[{"user":"user1","action":"lock","at":"2021-09-01T00:00:00Z","reason":"for deployment of revision 1a"}]}`,
+		"myproject2-prod":     `{"locked":true,"lockHistory":[{"user":"user1","action":"lock","at":"2021-09-01T00:00:00Z","reason":"for deployment of revision 2a"}]}`,
+		"myproject2-api-prod": `{"locked":true,"lockHistory":[{"user":"user1","action":"lock","at":"2021-09-01T00:00:00Z","reason":"for deployment of revision 3a"}]}`,
+	}, data)
+}

--- a/deploy/lock_encoding_test.go
+++ b/deploy/lock_encoding_test.go
@@ -58,11 +58,9 @@ func TestKeysAndValuesEncoding(t *testing.T) {
 					},
 				},
 			},
-			// TODO There's a known bug where "myproject2-api/prod" are conflated as "myproject2/prod".
-			// },
-			// "myproject2-api": {
-			// 	"prod": {
-			"api": {
+		},
+		"myproject2-api": {
+			"prod": {
 				Locked: true,
 				LockHistory: []LockHistoryItem{
 					{


### PR DESCRIPTION
This reveals and fixes the known bug in `describe locks` where it treats "myproject-api/prod" as "myproject/api" in `describe locks` output.

The first commit 272632ae38693b86068404d8dced59a1f09cfbc9 refactors the lock manager so that the lock, unlock, and describe locks against the encoded form of the locks info(=configmap data), can be tested without a K8s fake client or a K8s cluster. It also add unit tests and reveals the bug https://github.com/kufu-ai/gocat/commit/272632ae38693b86068404d8dced59a1f09cfbc9#diff-58fdb8b585fff39180c0d3e7e736adeccc351c620058e9d921d54704ace96d3cR61-R65.

The second commit c7810964299dbf373b1f118ec3fbbb83b023db7d fixes the bug and the test.

Related to #1155
